### PR TITLE
Fix not work in Windows

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -19,7 +19,7 @@ const debug = createDebug('cli');
 
 export const paths = getPaths('nxapi');
 
-export const dir = path.resolve(import.meta.url.substr(7), '..', '..');
+export const dir = path.resolve(import.meta.url.substr(process.platform === 'win32' ? 8 : 7), '..', '..');
 export const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf-8'));
 export const version = pkg.version;
 export const git = (() => {


### PR DESCRIPTION
The following error occurs when executing the `nxapi` command in a Windows environment.

```
C:\Users\Admin>nxapi
node:fs:590
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, open 'C:\C:\Users\Admin\scoop\persist\nodejs\bin\node_modules\nxapi\package.json'
    at Object.openSync (node:fs:590:3)
    at Module.readFileSync (node:fs:458:35)
    at file:///C:/Users/Admin/scoop/persist/nodejs/bin/node_modules/nxapi/dist/util.js:24:34
    at ModuleJob.run (node:internal/modules/esm/module_job:198:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:409:24) {
  errno: -4058,
  syscall: 'open',
  code: 'ENOENT',
  path: 'C:\\C:\\Users\\Admin\\scoop\\persist\\nodejs\\bin\\node_modules\\nxapi\\package.json'
}

Node.js v18.1.0
```

This is due to the path resolution for `package.json` not working as expected on Windows.
This patch fixes the above issue.