### PR TITLE
Add coop (salmon run) types and results for SplatNet 3

### DIFF
--- a/src/api/splatnet3-types.ts
+++ b/src/api/splatnet3-types.ts
@@ -244,6 +244,51 @@ export interface CurrentFestResult {
 /** c1553ac75de0a3ea497cdbafaa93e95b BankaraBattleHistoriesQuery */
 export type BankaraBattleHistoriesResult = unknown;
 
+/** 817618ce39bcf5570f52a97d73301b30 CoopHistoryQuery */
+export interface CoopHistoryResult {
+    coopResult: {
+        historyGroups: {
+            nodes: CoopHistoryGroup[];
+        };
+        historyGroupsOnlyFirst: unknown;
+        monthlyGear: unknown;
+        pointCard: unknown;
+        regularAverageClearWave: unknown;
+        regularGrade: unknown;
+        regularGradePoint: unknown;
+        scale: unknown;
+    }
+}
+interface CoopHistoryGroup {
+    historyDetails: {
+        nodes: CoopHistoryDetail[];
+    };
+}
+interface CoopHistoryDetail {
+    afterGrade: unknown;
+    afterGradePoint: unknown;
+    bossResult: unknown;
+    coopStage: unknown;
+    gradePointDiff: unknown;
+    id: string;
+    memberResults: unknown;
+    myResult: unknown;
+    nextHistoryDetail: {
+        id: string;
+    } | null;
+    previousHistoryDetail: {
+        id: string;
+    } | null;
+    resultWave: unknown;
+    waveResults: unknown;
+    weapons: unknown;
+}
+
+/** f3799a033f0a7ad4b1b396f9a3bafb1e CoopHistoryDetailQuery */
+export interface CoopHistoryDetailResult {
+    coopHistoryDetail: unknown;
+}
+
 /** 7d8b560e31617e981cf7c8aa1ca13a00 LatestBattleHistoriesQuery */
 export interface LatestBattleHistoriesResult {
     latestBattleHistories: {

--- a/src/api/splatnet3.ts
+++ b/src/api/splatnet3.ts
@@ -5,7 +5,7 @@ import { NintendoAccountUser } from './na.js';
 import { defineResponse, ErrorResponse } from './util.js';
 import CoralApi from './coral.js';
 import { timeoutSignal } from '../util/misc.js';
-import { BankaraBattleHistoriesResult, BattleHistoryCurrentPlayerResult, BulletToken, CurrentFestResult, FriendListResult, GraphQLRequest, GraphQLResponse, HistoryRecordResult, HomeResult, LatestBattleHistoriesResult, PrivateBattleHistoriesResult, RegularBattleHistoriesResult, RequestId, SettingResult, StageScheduleResult, VsHistoryDetailResult  } from './splatnet3-types.js';
+import { BankaraBattleHistoriesResult, BattleHistoryCurrentPlayerResult, BulletToken, CurrentFestResult, FriendListResult, GraphQLRequest, GraphQLResponse, HistoryRecordResult, HomeResult, LatestBattleHistoriesResult, PrivateBattleHistoriesResult, RegularBattleHistoriesResult, RequestId, SettingResult, StageScheduleResult, VsHistoryDetailResult, CoopHistoryResult, CoopHistoryDetailResult } from './splatnet3-types.js';
 
 const debug = createDebug('nxapi:api:splatnet3');
 
@@ -143,7 +143,13 @@ export default class SplatNet3Api {
     }
 
     async getCoopHistory() {
-        return this.persistedQuery<unknown>(RequestId.CoopHistoryQuery, {});
+        return this.persistedQuery<CoopHistoryResult>(RequestId.CoopHistoryQuery, {});
+    }
+
+    async getCoopHistoryDetail(id: string) {
+        return this.persistedQuery<CoopHistoryDetailResult>(RequestId.CoopHistoryDetailQuery, {
+            coopHistoryDetailId: id
+        });
     }
 
     static async createWithCoral(nso: CoralApi, user: NintendoAccountUser) {


### PR DESCRIPTION
This PR aims to add co-op details for `nxapi splatnet3 dump-results`.
![Screen Shot 2022-09-12 at 6 06 53 PM](https://user-images.githubusercontent.com/704971/189785809-791e97b5-ea8e-4077-a98e-92716f14eb78.png)

I don't write TypeScript, so I only implemented (or actually, copied from the battle results) a very minor part.