### PR TITLE
Add 599 error code

### DIFF
--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -23,6 +23,9 @@ export const temporary_http_errors = [
     523, // Origin Is Unreachable
     524, // A Timeout Occurred
     530, // Unknown (1xxx error)
+    
+    // Other non-standard errors
+    599, // Custom (GraphQL)
 ];
 
 export async function handleError(


### PR DESCRIPTION
Thanks for the updates! I've been trying the latest builds from gitlab and they've really cut down on the number of random errors. However, I do still see a "599" error occasionally. It may be thrown either by the nintendo GraphQL api or from the underlying HTTP library. Here's the backtrace I see:

![image](https://user-images.githubusercontent.com/233815/213930307-af278796-119d-445b-9042-642cd22d3f6e.png)

Doesn't look like there are any additional details. I've added the 599 error to the temporary_http_errors array, but let me know what you think.