### PR TITLE
Write timestamped daily dumps only for the current day 

### DIFF
--- a/src/cli/pctl/dump-summaries.ts
+++ b/src/cli/pctl/dump-summaries.ts
@@ -109,7 +109,7 @@ async function dumpDailySummariesForDevice(moon: MoonApi, directory: string, dev
 
     for (const summary of summaries.items) {
         const filename = 'pctl-daily-' + summary.deviceId + '-' + summary.date +
-            (summary.result === DailySummaryResult.ACHIEVED ? '' : '-' + timestamp) + '.json';
+            (summary.result === DailySummaryResult.COMPUTING ? '-' + timestamp : '') + '.json';
         const file = path.join(directory, filename);
 
         try {

--- a/src/cli/pctl/dump-summaries.ts
+++ b/src/cli/pctl/dump-summaries.ts
@@ -109,7 +109,7 @@ async function dumpDailySummariesForDevice(moon: MoonApi, directory: string, dev
 
     for (const summary of summaries.items) {
         const filename = 'pctl-daily-' + summary.deviceId + '-' + summary.date +
-            (summary.result === DailySummaryResult.COMPUTING ? '-' + timestamp : '') + '.json';
+            (summary.result === DailySummaryResult.CALCULATING ? '-' + timestamp : '') + '.json';
         const file = path.join(directory, filename);
 
         try {


### PR DESCRIPTION
Past days are either ACHIEVED or UNACHIEVED depending on whether the time limit has been reached. The current day is in state CALCULATING.

The current logic sets a timestamp for all days in state different from ACHIEVED, which means all past days when the time was not reached also get timestamped dumps. The correct behavior is to only append a timestamp for the current day.

Old behavior (every run after the first one creates 14 daily summaries because I have 13 days in state UNACHIEVED in the last month):

```
$ nxapi pctl dump-summaries xxxxxxxxxxxxxxxx 
Authenticating to Nintendo Switch Parental Controls app
Downloading summaries for device Xxx Xxx  (xxxxxxxxxxxxxxxx)
Downloaded 0 monthly and 14 daily summaries for device Xxx Xxx  (xxxxxxxxxxxxxxxx)
```

New behavior (every run after the first one creates just one daily summary for today):
```
$ nxapi pctl dump-summaries xxxxxxxxxxxxxxxx 
Authenticating to Nintendo Switch Parental Controls app
Downloading summaries for device Xxx Xxx  (xxxxxxxxxxxxxxxx)
Downloaded 0 monthly and 1 daily summaries for device Xxx Xxx  (xxxxxxxxxxxxxxxx)
```